### PR TITLE
Avoid capitalization of IAM policy 'Condition' element values

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,9 @@ _Currently only create and delete is supported, attempts to update a bucket are 
        action: "sqs:*"
   ```
 
+### IAM Roles
 
+| Property     | AWS SDK property | Notes
+|--------------|------------------|------
+| `policies`   | (No equivalent)  | The `policies` element contains an array of AWS IAM Policy definitions that are directly added to the role. The name of the policy is generated from the content, and updating works by comparing these names. **Note that automatic capitalization is not applied to the contents of the `Condition` of a policy.
+| `policyArns` | (No equivalent)  | The `policyArns` element contains an array of AWS IAM policy ARNs, which are attached to the role.

--- a/test/resources/iam.spec.js
+++ b/test/resources/iam.spec.js
@@ -1,0 +1,51 @@
+const chai = require('chai');
+const expect = chai.expect;
+
+const IAMRole = require('../../src/resources/iam');
+
+describe('iam', function utilsTest() {
+	describe('_translateAttributes behavior', () => {
+		it('doesn\'t change the operand of conditions', () => {
+			const iamRole = new IAMRole();
+			const attributes = iamRole._translateAttributes({
+				metadata: {
+					name: 'TestRole',
+				},
+				spec: {
+					policies: [
+						{
+							statement: [
+								{
+									action: ['ses:SendRawEmail'],
+									condition: {
+										StringEquals: {
+											'ses:FromAddress': 'me@example.com'
+										}
+									},
+									effect: 'Allow',
+									resource: '*',
+								}
+							]
+						}
+					]
+				}
+			});
+			expect(attributes.policies).to.be.deep.equal([
+				{
+					Statement: [
+						{
+							Action: ['ses:SendRawEmail'],
+							Condition: {
+								StringEquals: {
+									'ses:FromAddress': 'me@example.com'
+								}
+							},
+							Effect: 'Allow',
+							Resource: '*',
+						}
+					]
+				}
+			]);
+		});
+	});
+});


### PR DESCRIPTION
Anything under a 'Condition' element is case-sensitive, as can be both special AWS function names as well as special IAM policy condition keys. 

---
One question: instead of checking for 'Condition' to be the last path element, we could also check that it was the parent, so that we would be able to handle
```yaml
...
condition:
  stringEquals:
    'ses:FromAddress': 'me@example.com'
```

I've not been able to verify that we always have an AWS-capitalized function there, so I'd rather keep it like it is, and wait for a feature-request/bug-report that complains about this behavior.