### PR TITLE
Support S3 Versioning Configuration

### DIFF
--- a/src/resources/s3.js
+++ b/src/resources/s3.js
@@ -55,6 +55,17 @@ const logger = require('log4js').getLogger('S3');
  */
 
 /**
+ * Configuration of VersioningConfiguration.
+ *
+ * This structure is based on the definition in CloudFormation.
+ *
+ * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-versioningconfig.html
+ *
+ * @typedef VersioningConfiguration
+ * @property {("Enabled"|"Suspended")} status
+ */
+
+/**
  * A adapter for modifying AWS S3 buckets using Bucket definitions
  */
 class S3Bucket { // eslint-disable-line padded-blocks
@@ -128,6 +139,26 @@ class S3Bucket { // eslint-disable-line padded-blocks
 				BlockPublicPolicy: publicAccessBlockConfiguration.blockPublicPolicy,
 				IgnorePublicAcls: publicAccessBlockConfiguration.ignorePublicAcls,
 				RestrictPublicBuckets: publicAccessBlockConfiguration.restrictPublicBuckets,
+			},
+		};
+	}
+
+	/**
+	 * Translate the logging configuration into the 'versioning configuration' for the AWS SDK.
+	 *
+	 * @param {string} bucketName the bucket name
+	 * @param {VersioningConfiguration} versioningConfiguration Public Access Block configuration
+	 * @returns {Object} the parameters for `versioningConfiguration`, or `null`
+	 */
+	_translateVersioningConfiguration(bucketName, versioningConfiguration) {
+		if (!versioningConfiguration) {
+			return null;
+		}
+
+		return {
+			Bucket: bucketName,
+			VersioningConfiguration: {
+				Status: versioningConfiguration.status,
 			},
 		};
 	}
@@ -222,7 +253,7 @@ class S3Bucket { // eslint-disable-line padded-blocks
 	 */
 	_translateSpec(bucket) {
 		// Split the spec into parts
-		const {loggingConfiguration, bucketEncryption, publicAccessBlockConfiguration, policy, ...otherAttributes} = bucket.spec;
+		const {loggingConfiguration, bucketEncryption, publicAccessBlockConfiguration, versioningConfiguration, policy, ...otherAttributes} = bucket.spec;
 		const attributes = Object.keys(otherAttributes || {}).reduce((result, key) => {
 			const value = bucket.spec[key];
 			let resultKey;
@@ -247,6 +278,7 @@ class S3Bucket { // eslint-disable-line padded-blocks
 			policy: this._translatePolicy(bucket.metadata.name, policy),
 			publicAccessBlockParams: this._translatePublicAccessBlockConfiguration(bucket.metadata.name, publicAccessBlockConfiguration),
 			sseParams: this._translateBucketEncryption(bucket.metadata.name, bucketEncryption),
+			versioningConfiguration: this._translateVersioningConfiguration(bucket.metadata.name, versioningConfiguration),
 		};
 	}
 

--- a/src/resources/s3.js
+++ b/src/resources/s3.js
@@ -367,9 +367,7 @@ class S3Bucket { // eslint-disable-line padded-blocks
 		// set in S3: it should be suspended if the config isn't set in our config.
 		let versioningConfiguration;
 		if (!versioningConfigurationParams) {
-			const currentStatusRequest = Object.assign({}, versioningConfigurationParams, {
-				Bucket: bucketName,
-			});
+			const currentStatusRequest = {Bucket: bucketName};
 			const currentStatusRespose = await this._retryOnTransientNetworkErrors('S3::GetBucketVersioning', this.s3.getBucketVersioning, [currentStatusRequest]);
 			if (!currentStatusRespose.Status) {
 				// Not having versioning configuration for a bucket that was never configured is fine

--- a/src/resources/s3.js
+++ b/src/resources/s3.js
@@ -516,9 +516,7 @@ class S3Bucket { // eslint-disable-line padded-blocks
 			if (sseParams) {
 				await this._putBucketEncryption(bucket.metadata.name, sseParams);
 			}
-			if (versioningConfiguration) {
-				await this._putVersioningConfiguration(bucket.metadata.name, versioningConfiguration);
-			}
+			await this._putVersioningConfiguration(bucket.metadata.name, versioningConfiguration);
 
 			return response;
 		} catch (err) {
@@ -590,9 +588,7 @@ class S3Bucket { // eslint-disable-line padded-blocks
 			} else {
 				await this._deleteBucketEncryption(bucket.metadata.name);
 			}
-			if (versioningConfiguration) {
-				await this._putVersioningConfiguration(bucket.metadata.name, versioningConfiguration);
-			}
+			await this._putVersioningConfiguration(bucket.metadata.name, versioningConfiguration);
 
 			return response;
 		} catch (err) {

--- a/test/resources/s3.spec.js
+++ b/test/resources/s3.spec.js
@@ -375,6 +375,39 @@ describe('s3', function utilsTest() {
 				expect(versioningConfiguration).to.be.null;
 			});
 		});
+
+		describe('Versioning Configuration', () => {
+			it('translates Versioning configuration', () => {
+				const s3 = new S3Bucket();
+				const expectedResult = {
+					Bucket: 'TestBucket',
+					VersioningConfiguration: {
+						Status: 'Enabled',
+					},
+				};
+				const {versioningConfiguration} = s3._translateSpec({
+					metadata: {
+						name: 'TestBucket',
+					},
+					spec: {
+						versioningConfiguration: {
+							status: 'Enabled',
+						},
+					}
+				});
+				expect(versioningConfiguration).to.be.deep.equal(expectedResult);
+			});
+			it('returns null for missing Versioning configuration', () => {
+				const s3 = new S3Bucket();
+				const {versioningConfiguration} = s3._translateSpec({
+					metadata: {
+						name: 'TestBucket',
+					},
+					spec: {},
+				});
+				expect(versioningConfiguration).to.be.null;
+			});
+		});
 	});
 	describe('create behavior', () => {
 		it('invokes update when the bucket exists for this account', async() => {

--- a/test/resources/s3.spec.js
+++ b/test/resources/s3.spec.js
@@ -342,6 +342,39 @@ describe('s3', function utilsTest() {
 				expect(publicAccessBlockParams).to.be.null;
 			});
 		});
+
+		describe('Versioning Configuration', () => {
+			it('translates Versioning configuration', () => {
+				const s3 = new S3Bucket();
+				const expectedResult = {
+					Bucket: 'TestBucket',
+					VersioningConfiguration: {
+						Status: 'Enabled',
+					},
+				};
+				const {versioningConfiguration} = s3._translateSpec({
+					metadata: {
+						name: 'TestBucket',
+					},
+					spec: {
+						versioningConfiguration: {
+							status: 'Enabled',
+						},
+					}
+				});
+				expect(versioningConfiguration).to.be.deep.equal(expectedResult);
+			});
+			it('returns null for missing Versioning configuration', () => {
+				const s3 = new S3Bucket();
+				const {versioningConfiguration} = s3._translateSpec({
+					metadata: {
+						name: 'TestBucket',
+					},
+					spec: {},
+				});
+				expect(versioningConfiguration).to.be.null;
+			});
+		});
 	});
 	describe('create behavior', () => {
 		it('invokes update when the bucket exists for this account', async() => {


### PR DESCRIPTION
S3 allows to configure the Versioning behavior when creating buckets. This commit exposes this feature to the aws-resources configuration.

See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-versioningconfig.html